### PR TITLE
Add admin panel to create products with dynamic sizes, image and extras

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use App\Models\Extra;
+use App\Models\Product;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class ProductController extends Controller
+{
+    public function create()
+    {
+        $categories = Category::with('subcategories')->get();
+        $extras = Extra::all();
+        return view('admin.products.create', compact('categories', 'extras'));
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'subcategory_id' => ['required', 'exists:subcategories,id'],
+            'name' => ['required', 'string', 'max:255'],
+            'sizes' => ['required', 'array', 'min:1'],
+            'sizes.*.name' => ['required', 'string'],
+            'sizes.*.price' => ['required', 'numeric'],
+            'image' => ['nullable', 'image'],
+            'extras' => ['nullable', 'array'],
+            'extras.*' => ['exists:extras,id'],
+        ]);
+
+        $sizes = collect($validated['sizes'])->map(function ($size) {
+            return [
+                'name' => $size['name'],
+                'price' => (float) $size['price'],
+            ];
+        })->values();
+
+        $path = $request->file('image')
+            ? $request->file('image')->store('products', 'public')
+            : null;
+
+        Product::create([
+            'subcategory_id' => $validated['subcategory_id'],
+            'name' => $validated['name'],
+            'sizes' => $sizes,
+            'image' => $path,
+            'extras' => $validated['extras'] ?? [],
+        ]);
+
+        return redirect()->route('admin.products.create')
+            ->with('success', 'Product created.');
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -9,7 +9,12 @@ class Product extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['subcategory_id', 'name', 'size', 'price'];
+    protected $fillable = ['subcategory_id', 'name', 'sizes', 'image', 'extras'];
+
+    protected $casts = [
+        'sizes' => 'array',
+        'extras' => 'array',
+    ];
 
     // Un producto pertenece a una subcategoría
     public function subcategory()

--- a/database/migrations/2025_08_22_194103_create_products_table.php
+++ b/database/migrations/2025_08_22_194103_create_products_table.php
@@ -11,10 +11,13 @@ return new class extends Migration
         Schema::create('products', function (Blueprint $table) {
             $table->id();
             $table->foreignId('subcategory_id')->constrained('subcategories')->onDelete('cascade');
-            $table->string('name'); // Te faltaba el nombre del producto
-            $table->smallInteger('size')->nullable();
-            // Usamos decimal para precios: 10 dígitos en total, 2 decimales
-            $table->decimal('price', 10, 2);
+            $table->string('name');
+            // Store size/price pairs as JSON [{name: "Small", price: 1.99}, ...]
+            $table->json('sizes');
+            // Optional product image path
+            $table->string('image')->nullable();
+            // Array of extra option IDs associated with the product
+            $table->json('extras')->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/admin/products/create.blade.php
+++ b/resources/views/admin/products/create.blade.php
@@ -1,0 +1,122 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Add Product') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6 max-w-5xl mx-auto">
+        @if (session('success'))
+            <div class="mb-4 p-4 bg-green-100 text-green-800 rounded">
+                {{ session('success') }}
+            </div>
+        @endif
+
+        <form method="POST" action="{{ route('admin.products.store') }}" enctype="multipart/form-data" class="space-y-6">
+            @csrf
+            <div>
+                <label class="block font-medium text-sm text-gray-700">Name</label>
+                <input type="text" name="name" value="{{ old('name') }}" class="mt-1 block w-full rounded-md" required>
+            </div>
+
+            <div>
+                <label class="block font-medium text-sm text-gray-700">Category</label>
+                <select name="subcategory_id" class="mt-1 block w-full rounded-md" required>
+                    <option value="">Select...</option>
+                    @foreach ($categories as $category)
+                        <optgroup label="{{ $category->name }}">
+                            @foreach ($category->subcategories as $subcategory)
+                                <option value="{{ $subcategory->id }}" @selected(old('subcategory_id') == $subcategory->id)>
+                                    {{ $subcategory->name }}
+                                </option>
+                            @endforeach
+                        </optgroup>
+                    @endforeach
+                </select>
+            </div>
+
+            <div>
+                <label class="block font-medium text-sm text-gray-700">Sizes & Prices</label>
+                <table id="sizes-table" class="w-full text-sm border mt-1">
+                    <thead>
+                        <tr class="bg-gray-100">
+                            <th class="p-2">Size</th>
+                            <th class="p-2">Price</th>
+                            <th class="p-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="p-2"><input type="text" name="sizes[0][name]" class="w-full rounded-md"></td>
+                            <td class="p-2"><input type="number" step="0.01" name="sizes[0][price]" class="w-full rounded-md"></td>
+                            <td class="p-2 text-center"><button type="button" class="remove-row text-red-500">✕</button></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <button type="button" id="add-size" class="mt-2 px-3 py-1 bg-gray-200 rounded">Add Size</button>
+            </div>
+
+            <div>
+                <label class="block font-medium text-sm text-gray-700">Image</label>
+                <div id="drop-zone" class="mt-1 flex items-center justify-center w-full h-32 border-2 border-dashed rounded-md cursor-pointer">
+                    <span>Drop image here or click to upload</span>
+                </div>
+                <input type="file" name="image" id="image-input" class="hidden" accept="image/*">
+            </div>
+
+            <div>
+                <label class="block font-medium text-sm text-gray-700 mb-1">Extras</label>
+                <div class="space-y-1">
+                    @foreach ($extras as $extra)
+                        <label class="flex items-center space-x-2">
+                            <input type="checkbox" name="extras[]" value="{{ $extra->id }}">
+                            <span>{{ $extra->name }} (${{ number_format($extra->price, 2) }})</span>
+                        </label>
+                    @endforeach
+                </div>
+            </div>
+
+            <div>
+                <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
+            </div>
+        </form>
+    </div>
+
+    <script>
+        let sizeIndex = 1;
+        document.getElementById('add-size').addEventListener('click', function () {
+            const tbody = document.querySelector('#sizes-table tbody');
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td class="p-2"><input type="text" name="sizes[${sizeIndex}][name]" class="w-full rounded-md"></td>
+                <td class="p-2"><input type="number" step="0.01" name="sizes[${sizeIndex}][price]" class="w-full rounded-md"></td>
+                <td class="p-2 text-center"><button type="button" class="remove-row text-red-500">✕</button></td>
+            `;
+            tbody.appendChild(row);
+            sizeIndex++;
+        });
+
+        document.addEventListener('click', function (e) {
+            if (e.target.classList.contains('remove-row')) {
+                e.target.closest('tr').remove();
+            }
+        });
+
+        const dropZone = document.getElementById('drop-zone');
+        const imageInput = document.getElementById('image-input');
+        dropZone.addEventListener('click', () => imageInput.click());
+        dropZone.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            dropZone.classList.add('bg-gray-100');
+        });
+        dropZone.addEventListener('dragleave', (e) => {
+            e.preventDefault();
+            dropZone.classList.remove('bg-gray-100');
+        });
+        dropZone.addEventListener('drop', (e) => {
+            e.preventDefault();
+            dropZone.classList.remove('bg-gray-100');
+            imageInput.files = e.dataTransfer.files;
+        });
+    </script>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Admin\ProductController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -15,6 +16,10 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    // Product management routes
+    Route::get('/admin/products/create', [ProductController::class, 'create'])->name('admin.products.create');
+    Route::post('/admin/products', [ProductController::class, 'store'])->name('admin.products.store');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- allow admins to add products with sizes, image uploads and extras
- persist size/price pairs and extras on product records
- add product creation form and routes

## Testing
- `php artisan test` *(fails: Call to undefined method App\Models\User::factory())*

------
https://chatgpt.com/codex/tasks/task_e_68a8d2f4d00c8325bcfd2f9452fe043b