### PR TITLE
feat: seed drink categories with flavors and sizes

### DIFF
--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -2,10 +2,8 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
-use App\Models\Category; // Asegúrate de importar el modelo User
-use Illuminate\Support\Facades\Hash; // Importa el Facade para hashear la contraseña
+use App\Models\Category;
 
 class CategorySeeder extends Seeder
 {
@@ -14,11 +12,16 @@ class CategorySeeder extends Seeder
      */
     public function run(): void
     {
-        // Usuario Administrador
-        Category::create([ 'Name'    => 'Bloody Mary']);
-        Category::create([ 'Name'    => 'Clásicos con Vodka']);
-        Category::create([ 'Name'    => 'Aperol']);
-        Category::create([ 'Name'    => 'Sin Alcohol']);
-        Category::create([ 'Name'    => 'Café']);
+        $categories = [
+            'Bloody Mary',
+            'Vodka',
+            'Aperol',
+            'Sin Alcohol',
+            'Café',
+        ];
+
+        foreach ($categories as $name) {
+            Category::create(['name' => $name]);
+        }
     }
 }

--- a/database/seeders/SubcategorySeeder.php
+++ b/database/seeders/SubcategorySeeder.php
@@ -2,10 +2,9 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
-use App\Models\Subcategory; // Asegúrate de importar el modelo User
-use Illuminate\Support\Facades\Hash; // Importa el Facade para hashear la contraseña
+use App\Models\Category;
+use App\Models\Subcategory;
 
 class SubcategorySeeder extends Seeder
 {
@@ -14,23 +13,71 @@ class SubcategorySeeder extends Seeder
      */
     public function run(): void
     {
-        Subcategory::create([ 
-            'category_id'    => '1',
-            'name' => 'Clásico',
-        ]);
-        
-        Subcategory::create([ 
-            'category_id'    => '1',
-            'name' => 'Lime',
-        ]);
-        Subcategory::create([ 
-            'category_id'    => '1',
-            'name' => 'Strawberry',
-        ]);
-        Subcategory::create([ 
-            'category_id'    => '1',
-            'name' => 'Smokey',
+        $categories = Category::whereIn('name', [
+            'Bloody Mary',
+            'Vodka',
+            'Aperol',
+            'Sin Alcohol',
+            'Café',
+        ])->get()->keyBy('name');
+
+        // Bloody Mary flavours with common sizes
+        foreach (['Clásico', 'Raspberry', 'Lime', 'Smokey'] as $flavour) {
+            Subcategory::create([
+                'category_id' => $categories['Bloody Mary']->id,
+                'name' => $flavour,
+                'sizes' => [
+                    ['size_oz' => 16, 'price' => 100],
+                    ['size_oz' => 32, 'price' => 150],
+                ],
+            ]);
+        }
+
+        // Vodka options
+        Subcategory::create([
+            'category_id' => $categories['Vodka']->id,
+            'name' => 'Vodka Tonic',
+            'sizes' => [
+                ['size_oz' => 16, 'price' => 130],
+                ['size_oz' => 32, 'price' => 160],
+            ],
         ]);
 
+        Subcategory::create([
+            'category_id' => $categories['Vodka']->id,
+            'name' => 'Vodka Ricky',
+            'sizes' => [
+                ['size_oz' => 16, 'price' => 98],
+                ['size_oz' => 32, 'price' => 138],
+            ],
+        ]);
+
+        // Aperol
+        Subcategory::create([
+            'category_id' => $categories['Aperol']->id,
+            'name' => 'Aperol',
+            'sizes' => [
+                ['size_oz' => 16, 'price' => 120],
+            ],
+        ]);
+
+        // Sin Alcohol
+        Subcategory::create([
+            'category_id' => $categories['Sin Alcohol']->id,
+            'name' => 'Rusa',
+            'sizes' => [
+                ['size_oz' => 16, 'price' => 58],
+                ['size_oz' => 32, 'price' => 88],
+            ],
+        ]);
+
+        // Café
+        Subcategory::create([
+            'category_id' => $categories['Café']->id,
+            'name' => 'Café',
+            'sizes' => [
+                ['size_oz' => 16, 'price' => 35],
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- seed base drink categories using proper naming
- populate subcategories with flavour-specific sizes and prices

## Testing
- `composer test` *(fails: Call to undefined method App\Models\User::factory())*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a656790832593805d6a83f04acd