### PR TITLE
feat: seed products with image URLs

### DIFF
--- a/database/seeders/Data/ProductData.php
+++ b/database/seeders/Data/ProductData.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Database\Seeders\Data;
+
+class ProductData
+{
+    public static function get(): array
+    {
+        return [
+            [
+                'name' => 'Bloody Mary',
+                'subcategory' => 'Clásico',
+                'size_oz' => 16,
+                'price' => 100,
+                'image' => 'https://solovino.cerounocero.app/wp-content/uploads/2025/08/descargar-1.jpeg',
+            ],
+            [
+                'name' => 'Aperol',
+                'subcategory' => 'Aperol',
+                'size_oz' => 16,
+                'price' => 120,
+                'image' => 'https://solovino.cerounocero.app/wp-content/uploads/2025/08/Imagen-de-WhatsApp-2025-08-13-a-las-15.35.46_b085bce9.jpg',
+            ],
+            [
+                'name' => 'Rusa',
+                'subcategory' => 'Rusa',
+                'size_oz' => 16,
+                'price' => 58,
+                'image' => 'https://solovino.cerounocero.app/wp-content/uploads/2025/08/Imagen-de-WhatsApp-2025-08-14-a-las-10.43.27_c42cf1de-300x300.jpg',
+            ],
+            [
+                'name' => 'Café',
+                'subcategory' => 'Café',
+                'size_oz' => 16,
+                'price' => 35,
+                'image' => 'https://solovino.cerounocero.app/wp-content/uploads/2025/08/descargar-1-1-300x300.jpeg',
+            ],
+            [
+                'name' => 'Vodka Tonic',
+                'subcategory' => 'Vodka Tonic',
+                'size_oz' => 16,
+                'price' => 130,
+                'image' => 'https://solovino.cerounocero.app/wp-content/uploads/2025/08/Imagen-de-WhatsApp-2025-08-14-a-las-10.41.26_926bfb76-300x300.jpg',
+            ],
+            [
+                'name' => 'Vodka Ricky',
+                'subcategory' => 'Vodka Ricky',
+                'size_oz' => 16,
+                'price' => 98,
+                'image' => 'https://solovino.cerounocero.app/wp-content/uploads/2025/08/Imagen-de-WhatsApp-2025-08-14-a-las-10.42.45_08407a32-300x300.jpg',
+            ],
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
             UserSeeder::class,
             CategorySeeder::class,
             SubcategorySeeder::class,
+            ProductSeeder::class,
             // Aquí puedes agregar otros seeders que crees en el futuro
         ]);
     }

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Product;
+use App\Models\Subcategory;
+use Database\Seeders\Data\ProductData;
+use Illuminate\Database\Seeder;
+
+class ProductSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        foreach (ProductData::get() as $data) {
+            $subcategory = Subcategory::where('name', $data['subcategory'])->first();
+
+            if (! $subcategory) {
+                continue;
+            }
+
+            Product::create([
+                'subcategory_id' => $subcategory->id,
+                'name' => $data['name'],
+                'size_oz' => $data['size_oz'],
+                'price' => $data['price'],
+                'image' => $data['image'],
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated product seeder using SOLID-friendly data provider
- register ProductSeeder in DatabaseSeeder

## Testing
- `composer install`
- `./vendor/bin/pest` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab542938e88325b041446465140feb