### PR TITLE
Add POS order and test print buttons

### DIFF
--- a/app/Http/Controllers/Admin/PrinterController.php
+++ b/app/Http/Controllers/Admin/PrinterController.php
@@ -12,6 +12,23 @@ use App\Models\Order;
 
 class PrinterController extends Controller
 {
+    public function printTest()
+    {
+        try {
+            $printerIp = '192.168.100.87';
+            $connector = new NetworkPrintConnector($printerIp, 9100);
+            $printer = new Printer($connector);
+            $printer->text("=== PRUEBA DE IMPRESIÓN ===\n");
+            $printer->feed(2);
+            $printer->cut();
+            $printer->close();
+
+            return response()->json(['success' => true, 'message' => 'Impresión de prueba enviada.']);
+        } catch (Exception $e) {
+            return response()->json(['success' => false, 'message' => 'No se pudo conectar con la impresora: ' . $e->getMessage()], 500);
+        }
+    }
+
     public function printTicket(Request $request)
     {
         $validated = $request->validate([

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,7 @@ Route::middleware(['auth', 'verified', 'admin'])->prefix('admin')->name('admin.'
     Route::post('orders', [OrderController::class, 'store'])->name('orders.store');
     Route::post('orders/finalize', [OrderController::class, 'finalizeAndPrint'])->name('orders.finalize');
     Route::post('print-ticket', [PrinterController::class, 'printTicket'])->name('print.ticket');
+    Route::post('print-test', [PrinterController::class, 'printTest'])->name('print.test');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add `ImprimirPrueba` button to send a test page to the printer
- replace Guardar/Comanda/Cobrar with single `Ordenar` button that saves and prints the order
- expose printer test endpoint and wire up view logic

## Testing
- `php artisan test` *(fails: No application encryption key)*

------
https://chatgpt.com/codex/tasks/task_e_68ab705507b08325b22f562fcedf8dac